### PR TITLE
Edit Location quality of life changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,6 +1712,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "wasm-bindgen",
+ "wasm-logger",
  "web-sys",
 ]
 
@@ -5763,6 +5764,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074649a66bb306c8f2068c9016395fa65d8e08d2affcbf95acf3c24c3ab19718"
+dependencies = [
+ "log",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,6 +1704,7 @@ dependencies = [
  "dioxus",
  "dotenvy",
  "env_logger",
+ "gloo-timers",
  "log",
  "models",
  "reqwest",

--- a/dvd_categorizer_web/Cargo.toml
+++ b/dvd_categorizer_web/Cargo.toml
@@ -12,6 +12,7 @@ dioxus = { version = "0.7.3", features = ["router"] }
 log.workspace = true
 env_logger.workspace = true
 tracing.workspace = true
+wasm-logger = "0.2"
 dotenvy.workspace = true
 models = { path = "../models", features = [] }
 reqwest = { version = "0.12.15", default-features = false, features = ["json"] }

--- a/dvd_categorizer_web/Cargo.toml
+++ b/dvd_categorizer_web/Cargo.toml
@@ -18,8 +18,9 @@ reqwest = { version = "0.12.15", default-features = false, features = ["json"] }
 serde.workspace = true
 serde_json.workspace = true
 wasm-bindgen = "0.2"
-web-sys = { version = "0.3.77", features = ["Window", "Location", "Document", "Element", "HtmlElement", "CssStyleDeclaration", "EventTarget"] }
+web-sys = { version = "0.3.77", features = ["Window", "Location", "Document", "Element", "HtmlElement", "HtmlInputElement", "CssStyleDeclaration", "EventTarget"] }
 chrono = "0.4"
+gloo-timers = { version = "0.3", features = ["futures"] }
 
 [patch.crates-io]
 getrandom = { version = "0.2.15", features = ["js"] }

--- a/dvd_categorizer_web/assets/main.css
+++ b/dvd_categorizer_web/assets/main.css
@@ -102,6 +102,21 @@ body {
     background: #0d9c6e;
 }
 
+.button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.button:disabled:hover {
+    background: #10b981;
+}
+
+@keyframes ellipsis {
+    0% { content: '.'; }
+    33% { content: '..'; }
+    66% { content: '...'; }
+}
+
 .preview-section {
     margin-top: 20px;
 }
@@ -111,6 +126,52 @@ body {
     margin-bottom: 15px;
     font-size: 1.25rem;
     font-weight: 600;
+}
+
+.preview-wrapper {
+    position: relative;
+}
+
+.loading-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(15, 17, 22, 0.85);
+    backdrop-filter: blur(4px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    border-radius: 8px;
+}
+
+.loading-content {
+    text-align: center;
+    color: #e5e7eb;
+}
+
+.loading-content p {
+    margin-top: 15px;
+    font-size: 1.1rem;
+    font-weight: 500;
+    color: #0891b2;
+}
+
+.spinner {
+    width: 50px;
+    height: 50px;
+    margin: 0 auto;
+    border: 4px solid #374151;
+    border-top: 4px solid #0891b2;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
 }
 
 #hero {

--- a/dvd_categorizer_web/assets/movie_grid.css
+++ b/dvd_categorizer_web/assets/movie_grid.css
@@ -65,9 +65,38 @@
         opacity: 0.6;
         transform: scale(0.98);
     }
+    
+    /* When editing is active, blur all non-editing cards and disable hover effects */
+    .movie-grid.editing-active .movie-card:not(:has(.location-edit-container)) {
+        filter: blur(3px);
+        opacity: 0.6;
+        transform: scale(0.98);
+        pointer-events: none;
+    }
+    
+    /* Keep the editing card expanded */
+    .movie-grid.editing-active .movie-card:has(.location-edit-container) {
+        transform: translateY(-6px) scale(1.02);
+        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12), 0 8px 16px rgba(0, 0, 0, 0.08);
+        border-color: rgba(8, 145, 178, 0.3);
+    }
 }
 
 .movie-card:hover {
+    transform: translateY(-6px) scale(1.02);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12), 0 8px 16px rgba(0, 0, 0, 0.08);
+    border-color: rgba(8, 145, 178, 0.3);
+}
+
+/* Disable hover effects when editing is active */
+.movie-grid.editing-active .movie-card:hover {
+    transform: none;
+    box-shadow: none;
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
+/* But keep the editing card expanded even on hover */
+.movie-grid.editing-active .movie-card:has(.location-edit-container):hover {
     transform: translateY(-6px) scale(1.02);
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12), 0 8px 16px rgba(0, 0, 0, 0.08);
     border-color: rgba(8, 145, 178, 0.3);

--- a/dvd_categorizer_web/assets/movie_grid.css
+++ b/dvd_categorizer_web/assets/movie_grid.css
@@ -57,6 +57,21 @@
     border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
+/* When editing is active, keep the editing card expanded (always, not just on hover) */
+.movie-grid.editing-active .movie-card:has(.location-edit-container) {
+    transform: translateY(-6px) scale(1.02);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12), 0 8px 16px rgba(0, 0, 0, 0.08);
+    border-color: rgba(8, 145, 178, 0.3);
+}
+
+/* When editing is active, blur all non-editing cards */
+.movie-grid.editing-active .movie-card:not(:has(.location-edit-container)) {
+    filter: blur(3px);
+    opacity: 0.6;
+    transform: scale(0.98);
+    pointer-events: none;
+}
+
 /* Blur effect for non-hovered cards (desktop only) */
 @media (hover: hover) and (pointer: fine) {
     .movie-grid .movie-card:hover ~ .movie-card,
@@ -64,21 +79,6 @@
         filter: blur(3px);
         opacity: 0.6;
         transform: scale(0.98);
-    }
-    
-    /* When editing is active, blur all non-editing cards and disable hover effects */
-    .movie-grid.editing-active .movie-card:not(:has(.location-edit-container)) {
-        filter: blur(3px);
-        opacity: 0.6;
-        transform: scale(0.98);
-        pointer-events: none;
-    }
-    
-    /* Keep the editing card expanded */
-    .movie-grid.editing-active .movie-card:has(.location-edit-container) {
-        transform: translateY(-6px) scale(1.02);
-        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12), 0 8px 16px rgba(0, 0, 0, 0.08);
-        border-color: rgba(8, 145, 178, 0.3);
     }
 }
 
@@ -88,18 +88,13 @@
     border-color: rgba(8, 145, 178, 0.3);
 }
 
-/* Disable hover effects when editing is active */
-.movie-grid.editing-active .movie-card:hover {
-    transform: none;
+/* Disable hover effects on non-editing cards when editing is active */
+.movie-grid.editing-active .movie-card:not(:has(.location-edit-container)):hover {
+    transform: scale(0.98);
     box-shadow: none;
     border-color: rgba(255, 255, 255, 0.1);
-}
-
-/* But keep the editing card expanded even on hover */
-.movie-grid.editing-active .movie-card:has(.location-edit-container):hover {
-    transform: translateY(-6px) scale(1.02);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12), 0 8px 16px rgba(0, 0, 0, 0.08);
-    border-color: rgba(8, 145, 178, 0.3);
+    filter: blur(3px);
+    opacity: 0.6;
 }
 
 /* Movie poster */
@@ -172,7 +167,8 @@
     z-index: 10;
 }
 
-.movie-card:hover .movie-description {
+.movie-card:hover .movie-description,
+.movie-grid.editing-active .movie-card:has(.location-edit-container) .movie-description {
     display: block;
     overflow: visible;
     -webkit-line-clamp: unset;
@@ -250,11 +246,13 @@
     display: none;
 }
 
-.movie-card:hover .movie-genre-extra {
+.movie-card:hover .movie-genre-extra,
+.movie-grid.editing-active .movie-card:has(.location-edit-container) .movie-genre-extra {
     display: inline-block;
 }
 
-.movie-card:hover .movie-genre-more {
+.movie-card:hover .movie-genre-more,
+.movie-grid.editing-active .movie-card:has(.location-edit-container) .movie-genre-more {
     display: none;
 }
 

--- a/dvd_categorizer_web/src/components/location_editor.rs
+++ b/dvd_categorizer_web/src/components/location_editor.rs
@@ -1,0 +1,200 @@
+use dioxus::prelude::*;
+use models::UpdateLocationRequest;
+use wasm_bindgen::JsCast;
+
+async fn update_location_on_server(movie_id: i32, location: String) -> Result<(), String> {
+    let window = web_sys::window().ok_or("No window")?;
+    let hostname = window
+        .location()
+        .hostname()
+        .unwrap_or_else(|_| "127.0.0.1".to_string());
+    let server_port = std::env::var("server_port").unwrap_or("3000".to_string());
+
+    let request = UpdateLocationRequest { movie_id, location };
+
+    let client = reqwest::Client::new();
+    client
+        .post(format!("http://{hostname}:{server_port}/movie/location"))
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {}", e))?
+        .error_for_status()
+        .map_err(|e| format!("Server error: {}", e))?;
+
+    Ok(())
+}
+
+#[derive(Props, Clone, PartialEq)]
+pub struct LocationEditorProps {
+    pub movie_id: i32,
+    pub initial_location: String,
+    pub on_location_updated: EventHandler<(i32, String)>,
+}
+
+#[component]
+pub fn LocationEditor(props: LocationEditorProps) -> Element {
+    // Track the current displayed location separately from props for reactivity
+    let mut current_location = use_signal(|| props.initial_location.clone());
+    let mut editing = use_signal(|| false);
+    let mut location_input = use_signal(String::new);
+    let mut is_saving = use_signal(|| false);
+    let mut save_error = use_signal(|| None::<String>);
+    
+    let input_id = use_signal(|| format!("location-input-{}", props.movie_id));
+    
+    // Sync current_location when props change (Option 2B: parent updates flow to child)
+    use_effect(move || {
+        let new_location = props.initial_location.clone();
+        if current_location() != new_location {
+            current_location.set(new_location);
+        }
+    });
+    
+    // Focus input when editing mode is activated
+    use_effect(move || {
+        if editing() {
+            let id = input_id();
+            spawn(async move {
+                // Small delay to ensure DOM is updated
+                gloo_timers::future::TimeoutFuture::new(10).await;
+                if let Some(window) = web_sys::window() {
+                    if let Some(document) = window.document() {
+                        if let Some(element) = document.get_element_by_id(&id) {
+                            if let Some(input) = element.dyn_ref::<web_sys::HtmlInputElement>() {
+                                let _ = input.focus();
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    });
+
+    rsx! {
+        div {
+            class: "movie-info-row movie-location-row",
+
+            if editing() {
+                // Edit mode
+                div {
+                    class: "location-edit-container",
+                    span {
+                        class: "movie-info-label",
+                        "Location: "
+                    }
+                    input {
+                        id: "{input_id()}",
+                        class: "location-input",
+                        r#type: "text",
+                        value: "{location_input}",
+                        oninput: move |evt| location_input.set(evt.value()),
+                        disabled: is_saving(),
+                        onkeydown: move |evt| {
+                            if evt.key() == Key::Enter && !is_saving() {
+                                let on_updated = props.on_location_updated.clone();
+                                let movie_id = props.movie_id;
+                                spawn(async move {
+                                    is_saving.set(true);
+                                    save_error.set(None);
+
+                                    match update_location_on_server(movie_id, location_input()).await {
+                                        Ok(_) => {
+                                            let new_loc = location_input();
+                                            current_location.set(new_loc.clone());
+                                            on_updated.call((movie_id, new_loc));
+                                            editing.set(false);
+                                        }
+                                        Err(e) => {
+                                            log::error!("Failed to update location: {}", e);
+                                            save_error.set(Some(e));
+                                        }
+                                    }
+
+                                    is_saving.set(false);
+                                });
+                            } else if evt.key() == Key::Escape && !is_saving() {
+                                // Cancel on Escape
+                                editing.set(false);
+                                save_error.set(None);
+                                location_input.set(current_location());
+                            }
+                        },
+                    }
+                    button {
+                        class: "location-save-button",
+                        onclick: move |_| {
+                            let on_updated = props.on_location_updated.clone();
+                            let movie_id = props.movie_id;
+                            spawn(async move {
+                                is_saving.set(true);
+                                save_error.set(None);
+
+                                match update_location_on_server(movie_id, location_input()).await {
+                                    Ok(_) => {
+                                        let new_loc = location_input();
+                                        current_location.set(new_loc.clone());
+                                        on_updated.call((movie_id, new_loc));
+                                        editing.set(false);
+                                    }
+                                    Err(e) => {
+                                        log::error!("Failed to update location: {}", e);
+                                        save_error.set(Some(e));
+                                    }
+                                }
+
+                                is_saving.set(false);
+                            });
+                        },
+                        disabled: is_saving(),
+                        if is_saving() {
+                            "Saving..."
+                        } else {
+                            "Save"
+                        }
+                    }
+                    button {
+                        class: "location-cancel-button",
+                        onclick: move |_| {
+                            editing.set(false);
+                            save_error.set(None);
+                            location_input.set(current_location());
+                        },
+                        disabled: is_saving(),
+                        "Cancel"
+                    }
+                }
+
+                // Show error if present
+                if let Some(error) = save_error() {
+                    div {
+                        class: "location-error",
+                        "Error: {error}"
+                    }
+                }
+            } else {
+                // Display mode
+                div {
+                    class: "location-display-container",
+                    span {
+                        class: "movie-info-label",
+                        "Location: "
+                    }
+                    span {
+                        class: "movie-info-value location-value",
+                        "{current_location()}"
+                    }
+                    button {
+                        class: "location-edit-button",
+                        onclick: move |_| {
+                            location_input.set(current_location());
+                            editing.set(true);
+                            save_error.set(None);
+                        },
+                        "Edit"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dvd_categorizer_web/src/components/location_editor.rs
+++ b/dvd_categorizer_web/src/components/location_editor.rs
@@ -2,6 +2,11 @@ use dioxus::prelude::*;
 use models::UpdateLocationRequest;
 use wasm_bindgen::JsCast;
 
+// Context to track if any location editor is currently active
+pub fn use_editing_context() -> Signal<bool> {
+    use_context::<Signal<bool>>()
+}
+
 async fn update_location_on_server(movie_id: i32, location: String) -> Result<(), String> {
     let window = web_sys::window().ok_or("No window")?;
     let hostname = window
@@ -42,6 +47,14 @@ pub fn LocationEditor(props: LocationEditorProps) -> Element {
     let mut save_error = use_signal(|| None::<String>);
     
     let input_id = use_signal(|| format!("location-input-{}", props.movie_id));
+    
+    // Get global editing context
+    let mut global_editing = use_editing_context();
+    
+    // Update global editing state when local editing changes
+    use_effect(move || {
+        global_editing.set(editing());
+    });
     
     // Sync current_location when props change (Option 2B: parent updates flow to child)
     use_effect(move || {

--- a/dvd_categorizer_web/src/components/mod.rs
+++ b/dvd_categorizer_web/src/components/mod.rs
@@ -1,3 +1,4 @@
 pub mod display_movie;
+pub mod location_editor;
 pub mod movie_card;
 pub mod movie_grid;

--- a/dvd_categorizer_web/src/components/movie_grid.rs
+++ b/dvd_categorizer_web/src/components/movie_grid.rs
@@ -45,6 +45,7 @@ async fn update_location_on_server(movie_id: i32, location: String) -> Result<()
 pub struct SingleMovieCardProps {
     pub scored_movie: ScoredMovie,
     pub search_mode: models::SearchMode,
+    pub on_location_updated: EventHandler<(i32, String)>,
 }
 
 #[component]
@@ -80,16 +81,6 @@ fn MovieCard(props: SingleMovieCardProps) -> Element {
             });
         }
     });
-    
-    let location_opt = use_memo(
-        move || {
-            props
-                .scored_movie
-                .movie
-                .location
-                .clone()
-        },
-    );
 
     rsx! {
         div {
@@ -225,7 +216,7 @@ fn MovieCard(props: SingleMovieCardProps) -> Element {
                 }
 
                 // Location - Editable
-                if location_opt().is_some() {
+                if props.scored_movie.movie.location.is_some() {
                     div {
                         class: "movie-info-row movie-location-row",
 
@@ -247,14 +238,15 @@ fn MovieCard(props: SingleMovieCardProps) -> Element {
                                     onkeydown: move |evt| {
                                         if evt.key() == Key::Enter && !is_saving() {
                                             // Save on Enter
-                                            let new_location = location_input();
+                                            let on_updated = props.on_location_updated.clone();
                                             spawn(async move {
                                                 is_saving.set(true);
                                                 save_error.set(None);
 
-                                                match update_location_on_server(movie_id, new_location).await {
+                                                match update_location_on_server(movie_id, location_input()).await {
                                                     Ok(_) => {
                                                         log::info!("Successfully updated location for movie {}", movie_id);
+                                                        on_updated.call((movie_id, location_input()));
                                                         editing.set(false);
                                                     }
                                                     Err(e) => {
@@ -275,14 +267,15 @@ fn MovieCard(props: SingleMovieCardProps) -> Element {
                                 button {
                                     class: "location-save-button",
                                     onclick: move |_| {
-                                        let new_location = location_input();
+                                        let on_updated = props.on_location_updated.clone();
                                         spawn(async move {
                                             is_saving.set(true);
                                             save_error.set(None);
 
-                                            match update_location_on_server(movie_id, new_location).await {
+                                            match update_location_on_server(movie_id, location_input()).await {
                                                 Ok(_) => {
                                                     log::info!("Successfully updated location for movie {}", movie_id);
+                                                    on_updated.call((movie_id, location_input()));
                                                     editing.set(false);
                                                 }
                                                 Err(e) => {
@@ -329,13 +322,13 @@ fn MovieCard(props: SingleMovieCardProps) -> Element {
                                 }
                                 span {
                                     class: "movie-info-value location-value",
-                                    "{location_opt().unwrap()}"
+                                    "{props.scored_movie.movie.location.as_ref().unwrap()}"
                                 }
                                 button {
                                     class: "location-edit-button",
                                     onclick: move |_| {
-                                        if let Some(loc) = location_opt() {
-                                            location_input.set(loc);
+                                        if let Some(ref loc) = props.scored_movie.movie.location {
+                                            location_input.set(loc.clone());
                                         }
                                         editing.set(true);
                                         save_error.set(None);
@@ -355,6 +348,7 @@ fn MovieCard(props: SingleMovieCardProps) -> Element {
 pub struct MovieGridProps {
     pub movies: Arc<Vec<ScoredMovie>>,
     pub search_mode: models::SearchMode,
+    pub on_location_updated: EventHandler<(i32, String)>,
 }
 
 #[component]
@@ -363,7 +357,11 @@ pub fn MovieGrid(props: MovieGridProps) -> Element {
         div {
             class: "movie-grid movie-grid-cols-3",
             for scored_movie in props.movies.iter() {
-                MovieCard { scored_movie: scored_movie.clone(), search_mode: props.search_mode }
+                MovieCard { 
+                    scored_movie: scored_movie.clone(), 
+                    search_mode: props.search_mode,
+                    on_location_updated: props.on_location_updated.clone()
+                }
             }
         }
     }

--- a/dvd_categorizer_web/src/components/movie_grid.rs
+++ b/dvd_categorizer_web/src/components/movie_grid.rs
@@ -172,9 +172,13 @@ pub struct MovieGridProps {
 
 #[component]
 pub fn MovieGrid(props: MovieGridProps) -> Element {
+    // Create and provide editing context for all LocationEditors
+    let is_editing = use_signal(|| false);
+    use_context_provider(|| is_editing);
+    
     rsx! {
         div {
-            class: "movie-grid movie-grid-cols-3",
+            class: if is_editing() { "movie-grid movie-grid-cols-3 editing-active" } else { "movie-grid movie-grid-cols-3" },
             for scored_movie in props.movies.iter() {
                 MovieCard { 
                     key: "{scored_movie.movie.id}",

--- a/dvd_categorizer_web/src/components/movie_grid.rs
+++ b/dvd_categorizer_web/src/components/movie_grid.rs
@@ -1,45 +1,9 @@
 use chrono::{DateTime, Local, NaiveDateTime};
 use dioxus::prelude::*;
-use models::{ScoredMovie, UpdateLocationRequest};
+use models::ScoredMovie;
 use std::sync::Arc;
-use wasm_bindgen::JsCast;
 
-async fn update_location_on_server(movie_id: i32, location: String) -> Result<(), String> {
-    let window = web_sys::window().ok_or("No window")?;
-    let hostname = window
-        .location()
-        .hostname()
-        .unwrap_or_else(|_| "127.0.0.1".to_string());
-    let server_port = std::env::var("server_port").unwrap_or("3000".to_string());
-
-    let request = UpdateLocationRequest { movie_id, location };
-
-    let client = reqwest::Client::new();
-    client
-        .post(format!("http://{hostname}:{server_port}/movie/location"))
-        .json(&request)
-        .send()
-        .await
-        .map_err(
-            |e| {
-                format!(
-                    "Request failed: {}",
-                    e
-                )
-            },
-        )?
-        .error_for_status()
-        .map_err(
-            |e| {
-                format!(
-                    "Server error: {}",
-                    e
-                )
-            },
-        )?;
-
-    Ok(())
-}
+use crate::components::location_editor::LocationEditor;
 
 #[derive(Props, Clone, PartialEq)]
 pub struct SingleMovieCardProps {
@@ -50,37 +14,7 @@ pub struct SingleMovieCardProps {
 
 #[component]
 fn MovieCard(props: SingleMovieCardProps) -> Element {
-    let mut editing = use_signal(|| false);
-    let mut location_input = use_signal(String::new);
-    let mut is_saving = use_signal(|| false);
-    let mut save_error = use_signal(|| None::<String>);
-
-    let movie_id = props
-        .scored_movie
-        .movie
-        .id;
-    
-    let input_id = use_signal(|| format!("location-input-{}", movie_id));
-    
-    // Focus input when editing mode is activated
-    use_effect(move || {
-        if editing() {
-            let id = input_id();
-            spawn(async move {
-                // Small delay to ensure DOM is updated
-                gloo_timers::future::TimeoutFuture::new(10).await;
-                if let Some(window) = web_sys::window() {
-                    if let Some(document) = window.document() {
-                        if let Some(element) = document.get_element_by_id(&id) {
-                            if let Some(input) = element.dyn_ref::<web_sys::HtmlInputElement>() {
-                                let _ = input.focus();
-                            }
-                        }
-                    }
-                }
-            });
-        }
-    });
+    let movie_id = props.scored_movie.movie.id;
 
     rsx! {
         div {
@@ -216,127 +150,12 @@ fn MovieCard(props: SingleMovieCardProps) -> Element {
                 }
 
                 // Location - Editable
-                if props.scored_movie.movie.location.is_some() {
-                    div {
-                        class: "movie-info-row movie-location-row",
-
-                        if editing() {
-                            // Edit mode
-                            div {
-                                class: "location-edit-container",
-                                span {
-                                    class: "movie-info-label",
-                                    "Location: "
-                                }
-                                input {
-                                    id: "{input_id()}",
-                                    class: "location-input",
-                                    r#type: "text",
-                                    value: "{location_input}",
-                                    oninput: move |evt| location_input.set(evt.value()),
-                                    disabled: is_saving(),
-                                    onkeydown: move |evt| {
-                                        if evt.key() == Key::Enter && !is_saving() {
-                                            // Save on Enter
-                                            let on_updated = props.on_location_updated.clone();
-                                            spawn(async move {
-                                                is_saving.set(true);
-                                                save_error.set(None);
-
-                                                match update_location_on_server(movie_id, location_input()).await {
-                                                    Ok(_) => {
-                                                        log::info!("Successfully updated location for movie {}", movie_id);
-                                                        on_updated.call((movie_id, location_input()));
-                                                        editing.set(false);
-                                                    }
-                                                    Err(e) => {
-                                                        log::error!("Failed to update location: {}", e);
-                                                        save_error.set(Some(e));
-                                                    }
-                                                }
-
-                                                is_saving.set(false);
-                                            });
-                                        } else if evt.key() == Key::Escape && !is_saving() {
-                                            // Cancel on Escape
-                                            editing.set(false);
-                                            save_error.set(None);
-                                        }
-                                    },
-                                }
-                                button {
-                                    class: "location-save-button",
-                                    onclick: move |_| {
-                                        let on_updated = props.on_location_updated.clone();
-                                        spawn(async move {
-                                            is_saving.set(true);
-                                            save_error.set(None);
-
-                                            match update_location_on_server(movie_id, location_input()).await {
-                                                Ok(_) => {
-                                                    log::info!("Successfully updated location for movie {}", movie_id);
-                                                    on_updated.call((movie_id, location_input()));
-                                                    editing.set(false);
-                                                }
-                                                Err(e) => {
-                                                    log::error!("Failed to update location: {}", e);
-                                                    save_error.set(Some(e));
-                                                }
-                                            }
-
-                                            is_saving.set(false);
-                                        });
-                                    },
-                                    disabled: is_saving(),
-                                    if is_saving() {
-                                        "Saving..."
-                                    } else {
-                                        "Save"
-                                    }
-                                }
-                                button {
-                                    class: "location-cancel-button",
-                                    onclick: move |_| {
-                                        editing.set(false);
-                                        save_error.set(None);
-                                    },
-                                    disabled: is_saving(),
-                                    "Cancel"
-                                }
-                            }
-
-                            // Show error if present
-                            if let Some(error) = save_error() {
-                                div {
-                                    class: "location-error",
-                                    "Error: {error}"
-                                }
-                            }
-                        } else {
-                            // Display mode
-                            div {
-                                class: "location-display-container",
-                                span {
-                                    class: "movie-info-label",
-                                    "Location: "
-                                }
-                                span {
-                                    class: "movie-info-value location-value",
-                                    "{props.scored_movie.movie.location.as_ref().unwrap()}"
-                                }
-                                button {
-                                    class: "location-edit-button",
-                                    onclick: move |_| {
-                                        if let Some(ref loc) = props.scored_movie.movie.location {
-                                            location_input.set(loc.clone());
-                                        }
-                                        editing.set(true);
-                                        save_error.set(None);
-                                    },
-                                    "Edit"
-                                }
-                            }
-                        }
+                if let Some(ref location) = props.scored_movie.movie.location {
+                    LocationEditor {
+                        key: "{movie_id}-{location}",
+                        movie_id: movie_id,
+                        initial_location: location.clone(),
+                        on_location_updated: props.on_location_updated.clone()
                     }
                 }
             }
@@ -358,6 +177,7 @@ pub fn MovieGrid(props: MovieGridProps) -> Element {
             class: "movie-grid movie-grid-cols-3",
             for scored_movie in props.movies.iter() {
                 MovieCard { 
+                    key: "{scored_movie.movie.id}",
                     scored_movie: scored_movie.clone(), 
                     search_mode: props.search_mode,
                     on_location_updated: props.on_location_updated.clone()

--- a/dvd_categorizer_web/src/components/movie_grid.rs
+++ b/dvd_categorizer_web/src/components/movie_grid.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Local, NaiveDateTime};
 use dioxus::prelude::*;
 use models::{ScoredMovie, UpdateLocationRequest};
 use std::sync::Arc;
+use wasm_bindgen::JsCast;
 
 async fn update_location_on_server(movie_id: i32, location: String) -> Result<(), String> {
     let window = web_sys::window().ok_or("No window")?;
@@ -57,6 +58,29 @@ fn MovieCard(props: SingleMovieCardProps) -> Element {
         .scored_movie
         .movie
         .id;
+    
+    let input_id = use_signal(|| format!("location-input-{}", movie_id));
+    
+    // Focus input when editing mode is activated
+    use_effect(move || {
+        if editing() {
+            let id = input_id();
+            spawn(async move {
+                // Small delay to ensure DOM is updated
+                gloo_timers::future::TimeoutFuture::new(10).await;
+                if let Some(window) = web_sys::window() {
+                    if let Some(document) = window.document() {
+                        if let Some(element) = document.get_element_by_id(&id) {
+                            if let Some(input) = element.dyn_ref::<web_sys::HtmlInputElement>() {
+                                let _ = input.focus();
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    });
+    
     let location_opt = use_memo(
         move || {
             props
@@ -214,11 +238,39 @@ fn MovieCard(props: SingleMovieCardProps) -> Element {
                                     "Location: "
                                 }
                                 input {
+                                    id: "{input_id()}",
                                     class: "location-input",
                                     r#type: "text",
                                     value: "{location_input}",
                                     oninput: move |evt| location_input.set(evt.value()),
                                     disabled: is_saving(),
+                                    onkeydown: move |evt| {
+                                        if evt.key() == Key::Enter && !is_saving() {
+                                            // Save on Enter
+                                            let new_location = location_input();
+                                            spawn(async move {
+                                                is_saving.set(true);
+                                                save_error.set(None);
+
+                                                match update_location_on_server(movie_id, new_location).await {
+                                                    Ok(_) => {
+                                                        log::info!("Successfully updated location for movie {}", movie_id);
+                                                        editing.set(false);
+                                                    }
+                                                    Err(e) => {
+                                                        log::error!("Failed to update location: {}", e);
+                                                        save_error.set(Some(e));
+                                                    }
+                                                }
+
+                                                is_saving.set(false);
+                                            });
+                                        } else if evt.key() == Key::Escape && !is_saving() {
+                                            // Cancel on Escape
+                                            editing.set(false);
+                                            save_error.set(None);
+                                        }
+                                    },
                                 }
                                 button {
                                     class: "location-save-button",

--- a/dvd_categorizer_web/src/main.rs
+++ b/dvd_categorizer_web/src/main.rs
@@ -41,6 +41,8 @@ const AI_LIVE_RESULTS_CSS: Asset = asset!("/assets/ai_live_results.css");
 
 fn main() {
     console_error_panic_hook::set_once();
+    wasm_logger::init(wasm_logger::Config::default());
+    
     if let Err(e) = dotenv() {
         error!(
             "Error loading .env file: {}",

--- a/dvd_categorizer_web/src/views/ai_live_results.rs
+++ b/dvd_categorizer_web/src/views/ai_live_results.rs
@@ -351,7 +351,34 @@ pub fn AiLiveResults() -> Element {
             }
 
             // Movie grid section
-            MovieGrid { movies: Arc::clone(&movies()), search_mode: search_mode() }
+            MovieGrid { 
+                movies: Arc::clone(&movies()), 
+                search_mode: search_mode(),
+                on_location_updated: move |(movie_id, new_location): (i32, String)| {
+                    log::info!("Location update callback called for movie {} with location: {}", movie_id, new_location);
+                    // Update the movie in the list
+                    let current_movies = movies();
+                    let updated_movies: Vec<ScoredMovie> = current_movies
+                        .iter()
+                        .map(|scored_movie| {
+                            if scored_movie.movie.id == movie_id {
+                                let mut updated_movie = scored_movie.movie.clone();
+                                updated_movie.location = Some(new_location.clone());
+                                log::info!("Updated movie {} location to: {}", movie_id, new_location);
+                                ScoredMovie {
+                                    movie: updated_movie,
+                                    vector_score: scored_movie.vector_score,
+                                }
+                            } else {
+                                scored_movie.clone()
+                            }
+                        })
+                        .collect();
+                    let count = updated_movies.len();
+                    movies.set(Arc::new(updated_movies));
+                    log::info!("Movies signal updated, new count: {}", count);
+                }
+            }
         }
     }
 }

--- a/dvd_categorizer_web/src/views/insert_media.rs
+++ b/dvd_categorizer_web/src/views/insert_media.rs
@@ -11,6 +11,7 @@ pub fn InsertMedia() -> Element {
     let mut dvd_data: Signal<Arc<Vec<FullMovie>>> = use_signal(|| Arc::new(Vec::new()));
     let mut is_previewing: Signal<bool> = use_signal(|| false);
     let mut error_message: Signal<Option<String>> = use_signal(|| None);
+    let mut is_sending: Signal<bool> = use_signal(|| false);
 
     // Helper for pluralization
     let dvd_count = dvd_data().len();
@@ -139,8 +140,10 @@ pub fn InsertMedia() -> Element {
 
                         button {
                             class: "button button-success",
+                            disabled: is_sending(),
                             onclick: move |_| {
                                 spawn(async move {
+                                is_sending.set(true);
                                 error_message.set(None);
                                 let window = web_sys::window().unwrap();
                                 let location = window.location();
@@ -184,9 +187,14 @@ pub fn InsertMedia() -> Element {
                                         error_message.set(Some(err_msg));
                                     }
                                 }
+                                is_sending.set(false);
                             });
                             },
-                            "Send to Database"
+                            if is_sending() {
+                                "Sending..."
+                            } else {
+                                "Send to Database"
+                            }
                         }
                     }
                 }
@@ -196,16 +204,27 @@ pub fn InsertMedia() -> Element {
             if !dvd_data().is_empty() {
                 div { class: "preview-section",
                     h3 { class: "preview-title", "Preview ({dvd_count} {movie_word} found)" }
-                    {
-                        // Convert FullMovie to ScoredMovie for display (with 0 score for preview)
-                        let scored_movies: Arc<Vec<ScoredMovie>> = Arc::new(
-                            dvd_data().iter().map(|movie| ScoredMovie {
-                                movie: movie.clone(),
-                                vector_score: 0.0,
-                            }).collect()
-                        );
-                        rsx! {
-                            MovieGrid { movies: scored_movies, search_mode: models::SearchMode::Both }
+                    div { class: "preview-wrapper",
+                        {
+                            // Convert FullMovie to ScoredMovie for display (with 0 score for preview)
+                            let scored_movies: Arc<Vec<ScoredMovie>> = Arc::new(
+                                dvd_data().iter().map(|movie| ScoredMovie {
+                                    movie: movie.clone(),
+                                    vector_score: 0.0,
+                                }).collect()
+                            );
+                            rsx! {
+                                MovieGrid { movies: scored_movies, search_mode: models::SearchMode::Both }
+                            }
+                        }
+                        
+                        if is_sending() {
+                            div { class: "loading-overlay",
+                                div { class: "loading-content",
+                                    div { class: "spinner" }
+                                    p { "Sending to database..." }
+                                }
+                            }
                         }
                     }
                 }

--- a/dvd_categorizer_web/src/views/insert_media.rs
+++ b/dvd_categorizer_web/src/views/insert_media.rs
@@ -214,7 +214,27 @@ pub fn InsertMedia() -> Element {
                                 }).collect()
                             );
                             rsx! {
-                                MovieGrid { movies: scored_movies, search_mode: models::SearchMode::Both }
+                                MovieGrid { 
+                                    movies: scored_movies, 
+                                    search_mode: models::SearchMode::Both,
+                                    on_location_updated: move |(movie_id, new_location): (i32, String)| {
+                                        // Update the movie in the dvd_data list
+                                        let current_dvds = dvd_data();
+                                        let updated_dvds: Vec<FullMovie> = current_dvds
+                                            .iter()
+                                            .map(|movie| {
+                                                if movie.id == movie_id {
+                                                    let mut updated_movie = movie.clone();
+                                                    updated_movie.location = Some(new_location.clone());
+                                                    updated_movie
+                                                } else {
+                                                    movie.clone()
+                                                }
+                                            })
+                                            .collect();
+                                        dvd_data.set(Arc::new(updated_dvds));
+                                    }
+                                }
                             }
                         }
                         


### PR DESCRIPTION
Adds some nice quality of life changes for edit location functionality.

- Enter and escape now save and cancel.
- After saving a location successfully the UI now updates to reflect that change. A manual refresh of data is no longer required.
- When editing a card, mousing over others no longer triggers their mouseover styles.
- Code improvement to abstract away editing of location. This moves about 150 lines to a `LocationEdit` component. No quality of life for use but makes it easier to update going forward.